### PR TITLE
Added missing steps for init from empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ node dist/index.js serve --configuration configuration.json
 To start from scratch and create the initial project:
 
 ```sh
+npm init
+npm i typescript
 npx tsc --init
 npm i @hasura/ndc-sdk-typescript sqlite sqlite3
 ```


### PR DESCRIPTION
You need an existing npm project and typescript to be added before you can use tsc init.